### PR TITLE
Remove deprecated MPI-1 function

### DIFF
--- a/levels/cxxsupport/mpi_support.cc
+++ b/levels/cxxsupport/mpi_support.cc
@@ -158,7 +158,7 @@ MPI_Manager::MPI_Manager ( MPI_Comm comm ) : comm_(comm)
   if (!flag)
     {
     MPI_Init(0,0);
-    MPI_Errhandler_set( LS_COMM, MPI_ERRORS_ARE_FATAL);
+    MPI_Comm_set_errhandler( LS_COMM, MPI_ERRORS_ARE_FATAL);
     }
   MPI_Comm_size(LS_COMM, &num_ranks_);
   MPI_Comm_rank(LS_COMM, &rank_);


### PR DESCRIPTION
The library does not compile with OpenMPI 4.0.1. This happens because, as said in https://www.mpich.org/static/docs/v3.2/www3/MPI_Comm_set_errhandler.html, function `MPI_Errhandler_set` is a MPI-1 function that has been deprecated. This PR uses the new name `MPI_Comm_set_errhandler`, which is valid in the MPI-2 standard.