### PR TITLE
Add ifdef guard around inclusion of the omp.h header

### DIFF
--- a/src/conviqt_math.cpp
+++ b/src/conviqt_math.cpp
@@ -4,7 +4,9 @@
 
 #include <cstring>
 
-#include "omp.h"
+#ifdef _OPENMP
+# include <omp.h>
+#endif // ifdef _OPENMP
 
 /*
   int convolve()


### PR DESCRIPTION
When using a compiler that does not support OpenMP (e.g. clang on MacOS), the include of `omp.h` must be guarded.