### PR TITLE
Emit correct code if SSE2 not set

### DIFF
--- a/levels/cxxsupport/ls_sse_utils_cxx.h
+++ b/levels/cxxsupport/ls_sse_utils_cxx.h
@@ -389,8 +389,8 @@ template<> inline V4sf vcast (const V4si &a)
 template<> inline V2df vcast (const V4si &a)
   { return V2df (_mm_castsi128_pd(a.v)); }
 
-#endif
-
 } // namespace levels
+
+#endif
 
 #endif


### PR DESCRIPTION
If the preprocessor directive _SSE2_ is not set this patch will produce correct code. Was producing a single '}' before.